### PR TITLE
Update local site FAQ template

### DIFF
--- a/User-Help/LocalFAQTemplate.md
+++ b/User-Help/LocalFAQTemplate.md
@@ -17,7 +17,7 @@ $sitename currently has no additional guidelines beyond the Codidact TOS and Cod
 
 <!--- If you have a trust level or other custom authorization requirement --> 
 ## Why can't I post a question? 
-_You may not have verified your account yet. Make sure you've clicked the link sent to your email when you registered, or re-verify using the "Verify" button on your profile. If you're still having trouble, message one of the mods or reach out to the team using the community [Discord server](https://discord.com/invite/bv2aaGa).
+You may not have verified your account yet. Make sure you've clicked the link sent to your email when you registered, or re-verify using the "Verify" button on your profile. If you're still having trouble, message one of the mods or reach out to the team using the community [Discord server](https://discord.com/invite/bv2aaGa).
 
 <!--- If you have multiple categories on the site, a short description what they are for and what is on or off topic  -->
 ## What are the different categories for?

--- a/User-Help/LocalFAQTemplate.md
+++ b/User-Help/LocalFAQTemplate.md
@@ -4,33 +4,26 @@
 
 Welcome to $sitename! We're glad you're here. The following information is relevant primarily within this community. If you have a question that applies to the entire Codidact family of communities, you may want to look at our [Global FAQ](https://www.codidact.com/FAQ) or [Global TOS](https:www.codidact.com/TOS). 
 
-<!--- Tell your users the purpose of the community and the topics it covers -->
-## What is $sitename all about?
-_Valhalla is the home of anyone interested in the history and culture of the Scandinavian regions. We welcome posts on everything from ancient recipes to mythological fanfic crossovers._
+<!--- Tell your users the purpose of the community, who its members are, and the topics it welcomes -->
+## What is $sitename all about? 
+$sitename is about... 
 
 <!--- Links to the moderators' profiles may be helpful -->
-## Who are the moderators? 
-_Your moderators are:_
-- _Freyja_ 
-- _Thor_ 
+<!--- ## Who are the moderators? -->
 
 <!--- If you have additional rules or guidelines beyond the TOS -->
 ## What are the rules on $sitename? 
-- _Keep posts to the appropriate categories_
-- _Anything involving blood, nudity, or any other content that could reasonably be considered NSFW must be spoilered_
+$sitename currently has no additional guidelines beyond the Codidact TOS and Code of Conduct.
 
 <!--- If you have a trust level or other custom authorization requirement --> 
 ## Why can't I post a question? 
-_You may not have verified your account yet. Make sure you've clicked the link sent to your email when you registered, or re-verify using the "Verify" button on your profile. If you're still having trouble, message one of the mods._
+_You may not have verified your account yet. Make sure you've clicked the link sent to your email when you registered, or re-verify using the "Verify" button on your profile. If you're still having trouble, message one of the mods or reach out to the team using the community [Discord server](https://discord.com/invite/bv2aaGa).
 
-<!--- If you have multiple categories on the site -->
+<!--- If you have multiple categories on the site, a short description what they are for and what is on or off topic  -->
 ## What are the different categories for?
-- _**Modernity** is for any post that references current events_
-- _**Imagination** is for any content that is primarily fictional_
-- _Everything else belongs in **General**_
+Different categories are to help distinguish different kinds of posts or specific content. 
 
 <!--- If you use a non-inherited IP license --> 
-## What open-source license are posts on $sitename created under?
-_All posts are created under CC BY-SA 4.0 by default EXCEPT for posts in the Imagination category which fall under CDDL-1.1._
+<!--- ## What open-source license are posts on $sitename created under? -->
 
 


### PR DESCRIPTION
Removed references to a fantastical site. Template should now be fully usable as-is, if somewhat incomplete, allowing new site moderators to focus on more important things during the set-up process. 