### PR TITLE
Replaced forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ A work-in-progress, healthy alternative to the Stack Exchange Network.
 
 This project was created to coordinate and keep track of current efforts by a group of (mostly unsatisfied) users of Stack Overflow and the Stack Exchange Network to develop an alternative to these platforms.
 
-All relevant information can be found in our [wiki](https://github.com/codidact/docs/wiki). Please make sure to [check out the forum](https://forum.codidact.org) as well. Join our [Discord server](https://discord.gg/WZ7aTst) for live chat about the project.
+All relevant information can be found in our [wiki](https://github.com/codidact/docs/wiki). Please make sure to [check out the forum](https://meta.codidact.com) as well. Join our [Discord server](https://discord.gg/WZ7aTst) for live chat about the project.
 
 We also share a number of ideals and goals with the [TopAnswers project](https://github.com/topanswers/topanswers) - you may like to see what they're up to as well.


### PR DESCRIPTION
With the forum having been deprecated I replaced the link with Meta.