### PR TITLE
removed some  occurrences to reduce the effort of customizing new communities

### DIFF
--- a/User-Help/LocalFAQTemplate.md
+++ b/User-Help/LocalFAQTemplate.md
@@ -7,15 +7,15 @@
 Welcome to $sitename! We're glad you're here. The following information is relevant primarily within this community. If you have a question that applies to the entire Codidact family of communities, you may want to look at our [Global FAQ](https://www.codidact.com/FAQ) or [Global TOS](https:www.codidact.com/TOS). 
 
 <!--- Tell your users the purpose of the community, who its members are, and the topics it welcomes -->
-## What is $sitename all about? 
-$sitename is about... 
+## What is this community all about? 
+This community is for... <!-- the summary line from the site propoasl is a good thing to put here -->
 
 <!--- Links to the moderators' profiles may be helpful -->
 <!--- ## Who are the moderators? -->
 
 <!--- If you have additional rules or guidelines beyond the TOS -->
-## What are the rules on $sitename? 
-$sitename currently has no additional guidelines beyond the Codidact TOS and Code of Conduct.
+## What are the rules on this community?
+This community currently has no additional guidelines beyond the Codidact TOS and Code of Conduct.
 
 <!--- If you have a trust level or other custom authorization requirement --> 
 ## Why can't I post a question? 


### PR DESCRIPTION
We used $sitename in the local FAQ on the theory that we'd be able to automate filling that in, and maybe we will someday, but right now, every time I set up a new community I have to find and edit those.  Some need to stay, but others can be "this community" or similar without loss of fidelity, so that's my proposal in this PR.